### PR TITLE
pass swagger object to convertType calls

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -95,7 +95,7 @@ var getViewForSwagger2 = function(opts){
             var successfulResponseTypeIsRef = false;
             var successfulResponseType;
             try {
-                const convertedType = ts.convertType(op.responses['200']);
+                const convertedType = ts.convertType(op.responses['200'], swagger);
 
                 if(convertedType.target){
                     successfulResponseTypeIsRef = true;
@@ -199,7 +199,7 @@ var getViewForSwagger2 = function(opts){
                 } else if(parameter.in === 'formData'){
                     parameter.isFormParameter = true;
                 }
-                parameter.tsType = ts.convertType(parameter);
+                parameter.tsType = ts.convertType(parameter, swagger);
                 parameter.cardinality = parameter.required ? '' : '?';
                 method.parameters.push(parameter);
             });

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -22,7 +22,7 @@ function convertType(swaggerType, swagger) {
     };
     
     if (swaggerType.hasOwnProperty('schema')) {
-        return convertType(swaggerType.schema);
+        return convertType(swaggerType.schema, swagger);
     } else if (_.isString(swaggerType.$ref)) {
         typespec.tsType = 'ref';
         typespec.target = swaggerType.$ref.substring(swaggerType.$ref.lastIndexOf('/') + 1);
@@ -38,12 +38,12 @@ function convertType(swaggerType, swagger) {
     } else if (swaggerType.type === 'boolean') {
         typespec.tsType = 'boolean';
     } else if (swaggerType.type === 'array') {
-        typespec.elementType = convertType(swaggerType.items);
+        typespec.elementType = convertType(swaggerType.items, swagger);
         typespec.tsType = `Array<${typespec.elementType.target || typespec.elementType.tsType || 'any'}>`;
         typespec.isArray = true;
     } else if (swaggerType.type === 'object' && swaggerType.hasOwnProperty('additionalProperties')) {
         // case where a it's a Dictionary<string, someType>
-        typespec.elementType = convertType(swaggerType.additionalProperties);
+        typespec.elementType = convertType(swaggerType.additionalProperties, swagger);
         typespec.tsType = `{ [key: string]: ${typespec.elementType.target || typespec.elementType.tsType || 'any'} }`;
         typespec.isDictionary = true;
     } else /*if (swaggerType.type === 'object')*/ { //remaining types are created as objects
@@ -65,14 +65,14 @@ function convertType(swaggerType, swagger) {
                             }
                         });
                     } else {
-                        var property = convertType(ref);
+                        var property = convertType(ref, swagger);
                         typespec.properties.push(...property.properties);
                     }
                 });
             }
 
             _.forEach(swaggerType.properties, function (propertyType, propertyName) {
-                var property = convertType(propertyType);
+                var property = convertType(propertyType, swagger);
                 property.name = propertyName;
                 property.isRequired = _.includes(typespec.requiredPropertyNames, propertyName);
                 typespec.properties.push(property);


### PR DESCRIPTION
This is required to support the use of the `allOf` directive.